### PR TITLE
Fix affiliation and abstract MEDLINE bugs

### DIFF
--- a/lib/rayyan-formats-plugins/plugins/medline.rb
+++ b/lib/rayyan-formats-plugins/plugins/medline.rb
@@ -31,7 +31,7 @@ module RayyanFormats
           target.jissue = article['IP']&.to_i
           target.pagination = article['PG']
           target.authors = Array(article['AU'])
-          target.affiliation = get_multivalued_field_with_newline_merger article['AD']
+          target.affiliation = get_multivalued_field_with_newline_merger(article['AD']).first
           # Generates url from pmid stored in article['type']
           target.url = get_pubmed_url article['type']
           target.language = article['LA']

--- a/lib/rayyan-formats-plugins/plugins/medline.rb
+++ b/lib/rayyan-formats-plugins/plugins/medline.rb
@@ -31,7 +31,7 @@ module RayyanFormats
           target.jissue = article['IP']&.to_i
           target.pagination = article['PG']
           target.authors = Array(article['AU'])
-          target.affiliation = get_multivalued_field_with_newline_merger(article['AD']).first
+          target.affiliation = get_multivalued_field_with_newline_merger(article['AD']).join('; ') if article['AD']
           # Generates url from pmid stored in article['type']
           target.url = get_pubmed_url article['type']
           target.language = article['LA']

--- a/lib/rayyan-formats-plugins/plugins/medline.rb
+++ b/lib/rayyan-formats-plugins/plugins/medline.rb
@@ -141,11 +141,12 @@ module RayyanFormats
         end
 
         def get_multivalued_field_with_newline_merger(values)
-          return unless values
+          return [] unless values
 
           # If single-valued string field, convert to array
           values_to_get = Array(values)
 
+          # Get rid of extra spaces created by newline merger
           values_to_get.map! do |value|
             value.gsub(/\s+/, ' ')
           end

--- a/lib/rayyan-formats-plugins/plugins/medline.rb
+++ b/lib/rayyan-formats-plugins/plugins/medline.rb
@@ -41,6 +41,7 @@ module RayyanFormats
           target.abstracts = get_multivalued_field_with_newline_merger article['AB']
           target.notes = article['GN']
           target.article_ids = get_article_ids article
+          target.copyright = article['CI']
 
           block.call(target, total)
         end

--- a/lib/rayyan-formats-plugins/version.rb
+++ b/lib/rayyan-formats-plugins/version.rb
@@ -1,5 +1,5 @@
 module RayyanFormats
   module Plugins
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/spec/plugins/medline_spec.rb
+++ b/spec/plugins/medline_spec.rb
@@ -78,6 +78,7 @@ describe MEDLINE do
               { idtype: :pii, value: '88/4/401M [pii]' }
             ]
           )
+          expect(target.copyright).to eq('©2017 American Society of Radiologic Technologists.')
         when 2
           expect(target.publication_types).to eq(['Introductory Journal Article'])
           expect(target.sid).to eq('20521754')

--- a/spec/plugins/medline_spec.rb
+++ b/spec/plugins/medline_spec.rb
@@ -135,7 +135,13 @@ describe MEDLINE do
             ['Kolak A', 'Kamińska M', 'Sygit K', 'Budny A', 'Surdyka D', 'Kukiełka-Budny B', 'Burdan F']
           )
           expect(target.affiliation).to eq(
-              "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland. agkola@interia.pl."
+            "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland. agkola@interia.pl.; " +
+            "St. John's Cancer Center, Department of Oncology, Lublin, Poland.; " +
+            "University of Szczecin, Faculty of Physical Education and Health Promotion, Szczecin, Poland.; " +
+            "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland.; " +
+            "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland.; " +
+            "St. John's Cancer Center, Department of Oncology, Lublin, Poland.; " +
+            "Human Anatomy Department, Medical Univeristy of Lublin, Poland."
           )
           expect(target.article_ids).to eq(
             [

--- a/spec/plugins/medline_spec.rb
+++ b/spec/plugins/medline_spec.rb
@@ -37,7 +37,7 @@ describe MEDLINE do
           expect(target.jissue).to eq(2)
           expect(target.pagination).to eq('55-64')
           expect(target.authors).to eq(['Wörmann B'])
-          expect(target.affiliation).to eq(['Medizinische Klinik mit Schwerpunkt Hämatologie'])
+          expect(target.affiliation).to eq('Medizinische Klinik mit Schwerpunkt Hämatologie')
           expect(target.url).to eq('https://pubmed.ncbi.nlm.nih.gov/29952495/')
           expect(target.language).to eq(%w[eng ger])
           expect(target.publisher_location).to eq('Germany')
@@ -91,8 +91,8 @@ describe MEDLINE do
           expect(target.pagination).to eq('1339-46')
           expect(target.authors).to eq(['Maughan KL', 'Lutterbie MA', 'Ham PS'])
           expect(target.affiliation).to eq(
-            ['Department of Family Medicine, University of Virginia School of Medicine, ' +
-            'Charlottesville, VA 22908, USA. kmaughan@virginia.edu']
+            'Department of Family Medicine, University of Virginia School of Medicine, ' +
+            'Charlottesville, VA 22908, USA. kmaughan@virginia.edu'
           )
           expect(target.url).to eq('https://pubmed.ncbi.nlm.nih.gov/20521754/')
           expect(target.language).to eq('eng')
@@ -134,15 +134,7 @@ describe MEDLINE do
             ['Kolak A', 'Kamińska M', 'Sygit K', 'Budny A', 'Surdyka D', 'Kukiełka-Budny B', 'Burdan F']
           )
           expect(target.affiliation).to eq(
-            [
-              "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland. agkola@interia.pl.",
-              "St. John's Cancer Center, Department of Oncology, Lublin, Poland.",
-              'University of Szczecin, Faculty of Physical Education and Health Promotion, Szczecin, Poland.',
-              "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland.",
-              "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland.",
-              "St. John's Cancer Center, Department of Oncology, Lublin, Poland.",
-              'Human Anatomy Department, Medical Univeristy of Lublin, Poland.'
-            ]
+              "St. John's Cancer Center, Department of Radiotherapy, Lublin, Poland. agkola@interia.pl."
           )
           expect(target.article_ids).to eq(
             [
@@ -157,7 +149,7 @@ describe MEDLINE do
           expect(target.date_array).to eq(%w[2011 11])
           expect(target.authors).to eq(['DeSantis C', 'Siegel R', 'Bandi P', 'Jemal A'])
           expect(target.affiliation).to eq(
-            ['Epidemiologist, Surveillance Research, American Cancer Society, Atlanta, GA 30303, USA. carol.desantis@cancer.org']
+            'Epidemiologist, Surveillance Research, American Cancer Society, Atlanta, GA 30303, USA. carol.desantis@cancer.org'
           )
           expect(target.article_ids).to eq(
             [


### PR DESCRIPTION
- Rayyan only accepts affiliation as a string and not an array. This patch returns the first affiliation that is encountered as a string.
- Returns empty array instead of `nil` when abstract doesn't exist in an entry.

